### PR TITLE
fix: default static header to true

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,7 +3,7 @@
   import StaticHeader from "@components/StaticHeader.svelte";
   import ScrollingHeader from "@components/ScrollingHeader.svelte";
 
-  let isInvIew: boolean;
+  let isInvIew = true;
 
   function handleChange({ detail }: CustomEvent<ObserverEventDetails>) {
     isInvIew = detail.inView;


### PR DESCRIPTION
Fix the issue where the scroll header appears initially, because isInView defaults to undefined.